### PR TITLE
Allow `xml: name: root` to skip a nested XML element.

### DIFF
--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -846,6 +846,13 @@ SwaggerUi.partials.signature = (function () {
       attrs.push(namespace);
     }   
 
+    // This hack gets around the fact that Swagger UI won't allow you to
+    // provide a JSON property that is also the root XML element.
+    if (xml && xml.name === 'root') {
+      var prop = _.keys(properties)[0];
+      return createSchemaXML(prop, properties[prop], models, config);
+    }
+
     if (!properties && !additionalProperties) { return getErrorMessage(); }
 
     properties = properties || {};


### PR DESCRIPTION
This PR sets a special
```yaml
xml:
  name: root
```
in a swagger descriptor for the pru On encountering this flag, the first property of the object is converted directly into XML, rather than being nested.

So:
```yaml
xml:
  name: root
properties:
  data:
    example: 123
```
will be converted to `<data>123</data>`, not `<root><data>123</data></root>`.