### PR TITLE
Allows arrays in XML examples

### DIFF
--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -746,7 +746,7 @@ SwaggerUi.partials.signature = (function () {
     var config = descriptor.config;
     var definition = descriptor.definition;
     var models = descriptor.models;
-    var value;
+    var value = '';
     var items = definition.items;
     var xml = definition.xml || {};
     var namespace = getNamespace(xml);
@@ -758,7 +758,12 @@ SwaggerUi.partials.signature = (function () {
     if(items.xml && items.xml.name) {
         key = items.xml.name;
     }
-    value = createSchemaXML(key, items, models, config);
+    if (!_.isArray(items)) {
+      items = [items];
+    }
+    items.forEach(function(item) {
+      value += createSchemaXML(key, item, models, config);
+    });
     if (namespace) {
       attributes.push(namespace);
     }

--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -760,6 +760,12 @@ SwaggerUi.partials.signature = (function () {
     }
     if (!_.isArray(items)) {
       items = [items];
+      // If items is an array, you can't also have an items.xml property.
+      // So use the root xml property of the array. Note this means you
+      // can't have a wrapped array that also has multiple item examples.
+      if (xml && xml.name) {
+        key = xml.name;
+      }
     }
     items.forEach(function(item) {
       value += createSchemaXML(key, item, models, config);

--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -758,14 +758,15 @@ SwaggerUi.partials.signature = (function () {
     if(items.xml && items.xml.name) {
         key = items.xml.name;
     }
-    if (!_.isArray(items)) {
-      items = [items];
+    if (_.isArray(items)) {
       // If items is an array, you can't also have an items.xml property.
       // So use the root xml property of the array. Note this means you
       // can't have a wrapped array that also has multiple item examples.
       if (xml && xml.name) {
         key = xml.name;
       }
+    } else {
+      items = [items];
     }
     items.forEach(function(item) {
       value += createSchemaXML(key, item, models, config);


### PR DESCRIPTION
This PR updates Swagger UI to concatenate arrays if the `items` entry is an array.