### PR TITLE
Add XML example logic for a simple primitive.

### DIFF
--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -904,6 +904,9 @@ SwaggerUi.partials.signature = (function () {
   }
 
   function createSchemaXML (name, definition, models, config) {
+    if (definition.example) {
+      return wrapTag(name, definition.example);
+    }
     var $ref = _.isObject(definition) ? definition.$ref : null;
     var output, index;
     config = config || {};


### PR DESCRIPTION
Swagger UI lacks even basic functionality for XML examples if it overlaps a ref 😱 